### PR TITLE
Fix joy_node Launch Parameter

### DIFF
--- a/zebROS_ws/src/controller_node/launch/joysticks_sim.launch
+++ b/zebROS_ws/src/controller_node/launch/joysticks_sim.launch
@@ -15,6 +15,7 @@
 		<node name="joy_node" pkg="joy" type="joy_node" output="screen">
 			<param name="autorepeat_rate" type="double" value="100"/>
 			<param name="coalesce_interval" type="double" value="0.01"/>
+			<param name="deadzone" type="double" value="0.0"/>
 		</node>
 		<node pkg="teleop_joystick_control" type="joystick_remap.py" name="joystick_remap" >
 			<remap from="joy_in" to="/joy0/joy" />
@@ -27,6 +28,7 @@
 			<param name="dev" value="/dev/input/js1"/>
 			<param name="autorepeat_rate" type="double" value="100"/>
 			<param name="coalesce_interval" type="double" value="0.01"/>
+			<param name="deadzone" type="double" value="0.0"/>
 		</node>
 		<node pkg="teleop_joystick_control" type="joystick_remap.py" name="joystick_remap" >
 			<remap from="joy_in" to="/joy1/joy" />


### PR DESCRIPTION
Apparently I screwed up when I added this parameter to the joysticks_sim.launch file. It was meant to limit the rate at which the joy_node could publish, therefore lagging out ubuntu less when axes were being moved. This change will only affect the sim behavior, as the joy_node is never launched on a physical robot.