### PR TITLE
Minor bug-fixes in hw interface error checking

### DIFF
--- a/zebROS_ws/src/ros_control_boilerplate/src/frcrobot_hw_interface.cpp
+++ b/zebROS_ws/src/ros_control_boilerplate/src/frcrobot_hw_interface.cpp
@@ -1716,7 +1716,7 @@ void FRCRobotHWInterface::write(ros::Duration &elapsed_time)
 			// the next time through the loop.
 			bool rc = safeTalonCall(victor->ConfigSensorTerm(ctre::phoenix::motorcontrol::SensorTerm::SensorTerm_Sum0, victor_sensor_terms[hardware_interface::SensorTerm_Sum0], timeoutMs),"ConfigSensorTerm Sum0");
 			rc &= safeTalonCall(victor->ConfigSensorTerm(ctre::phoenix::motorcontrol::SensorTerm::SensorTerm_Sum1, victor_sensor_terms[hardware_interface::SensorTerm_Sum1], timeoutMs),"ConfigSensorTerm Sum1");
-			rc = safeTalonCall(victor->ConfigSensorTerm(ctre::phoenix::motorcontrol::SensorTerm::SensorTerm_Diff0, victor_sensor_terms[hardware_interface::SensorTerm_Diff0], timeoutMs),"ConfigSensorTerm Diff0");
+			rc &= safeTalonCall(victor->ConfigSensorTerm(ctre::phoenix::motorcontrol::SensorTerm::SensorTerm_Diff0, victor_sensor_terms[hardware_interface::SensorTerm_Diff0], timeoutMs),"ConfigSensorTerm Diff0");
 			rc &= safeTalonCall(victor->ConfigSensorTerm(ctre::phoenix::motorcontrol::SensorTerm::SensorTerm_Diff1, victor_sensor_terms[hardware_interface::SensorTerm_Diff1], timeoutMs),"ConfigSensorTerm Diff1");
 			if (rc)
 			{

--- a/zebROS_ws/src/talon_interface/include/talon_interface/talon_command_interface.h
+++ b/zebROS_ws/src/talon_interface/include/talon_interface/talon_command_interface.h
@@ -879,7 +879,7 @@ class TalonHWCommand
 				return;
 			}
 
-			if ((feedback_device <  FeedbackDevice_Uninitialized) &&
+			if ((feedback_device <  FeedbackDevice_Uninitialized) ||
 				(feedback_device >= FeedbackDevice_Last) )
 			{
 				ROS_WARN_STREAM("setSensorTerm Invalid feedback device requested");

--- a/zebROS_ws/src/talon_interface/include/talon_interface/talon_state_interface.h
+++ b/zebROS_ws/src/talon_interface/include/talon_interface/talon_state_interface.h
@@ -1292,7 +1292,7 @@ class TalonHWState
 				return;
 			}
 
-			if ((feedback_device <  FeedbackDevice_Uninitialized) &&
+			if ((feedback_device <  FeedbackDevice_Uninitialized) ||
 				(feedback_device >= FeedbackDevice_Last) )
 			{
 				ROS_WARN_STREAM("setSensorTerm Invalid feedback device requested");


### PR DESCRIPTION
Fix three errors (two are copy-pastes of each other) in hardware interface error checking

In the first, rc is supposed to be the and'd return code value of a sequence of calls. One of the lines is accidentally a pure assignment.

The other is checking that a variable is out of range.  Code had &&. should have been || to check if it was either too low OR too high 