### PR TITLE
Add various bash aliases for common commands

### DIFF
--- a/zebROS_ws/command_aliases.sh
+++ b/zebROS_ws/command_aliases.sh
@@ -1,9 +1,9 @@
 # Aliases are short commands to replace long ones.
 
-alias natbuild='~/2019Offseason/zebROS_ws/native_build.sh'
 alias crossbuild='~/2019Offseason/zebROS_ws/cross_build.sh'
 alias deploy='~/2019Offseason/deploy.sh'
 alias hwlaunch='roslaunch controller_node 2019_compbot_combined.launch'
+alias natbuild='~/2019Offseason/zebROS_ws/native_build.sh'
 alias rosjet='source ~/2019Offseason/zebROS_ws/ROSJetsonMaster.sh'
 alias rosstd='source ~/2019Offseason/zebROS_ws/ROSStandard.sh'
 alias simlaunch='roslaunch controller_node 2019_compbot_combined.launch hw_or_sim:=sim joy_or_key:=key'


### PR DESCRIPTION
Aimed at helping reduce the time taken by typing long commands and changing directories too often. Note: source command_aliases.sh before these will work.