### PR TITLE
Add Auto Start Script (Concept)

### DIFF
--- a/zebROS_ws/auto_start.sh
+++ b/zebROS_ws/auto_start.sh
@@ -1,0 +1,25 @@
+# Would be a part of the .bashrc file and run upon entering your container.
+
+cd ~/2019Offseason/zebROS_ws/
+
+read -p "Pull code? (rebase) Y/n" -n 1 -r
+echo    # (optional) move to a new line
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+	git pull -r
+fi
+
+read -p "Run native build? Y/n" -n 1 -r
+echo    # (optional) move to a new line
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+	./native_build.sh
+fi
+
+read -p "Source ROSStandard? Y/n" -n 1 -r
+echo    # (optional) move to a new line
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+	source ~/2019Offseason/zebROS_ws/ROSStandard.sh
+	echo 'Sourced ROSStandard.sh'
+fi


### PR DESCRIPTION
Just an idea at this point, not rigorously tested. Also not sure if this is a good idea to add right now. The auto_start.sh script would actually be at the bottom of the .bashrc file in the docker image.

Intended functionality: upon entering the container, you will be

- Prompted to confirm or deny pulling code
- Prompted to confirm or deny a native build
- Prompted to confirm or deny sourcing ROSStandard.sh
- Moved to the zebROS_ws directory