### PR TITLE
Fix crash in base trajectory with only one point

### DIFF
--- a/zebROS_ws/src/base_trajectory/src/base_trajectory.cpp
+++ b/zebROS_ws/src/base_trajectory/src/base_trajectory.cpp
@@ -1198,7 +1198,12 @@ bool callback(base_trajectory::GenerateSpline::Request &msg,
 	// Hold current position if trajectory is empty
 	if (msg.points.empty())
 	{
-		ROS_DEBUG("Empty trajectory command, stopping.");
+		ROS_ERROR("Empty trajectory command, nothing to do.");
+		return false;
+	}
+	if (msg.points.size() < 2)
+	{
+		ROS_ERROR("Need at least two points - add a starting point at time 0?");
 		return false;
 	}
 	// TODO - operate in two modes
@@ -1280,6 +1285,7 @@ bool callback(base_trajectory::GenerateSpline::Request &msg,
 	trajectoryToSplineResponseMsg(tmp_msg, trajectory, jointNames);
 	writeMatlabCode(tmp_msg);
 	messageFilter.disable();
+	fflush(stdout);
 
 	if (!RPROP(trajectory,
 				msg.points,


### PR DESCRIPTION
In base_trajectory, check that there are at least 2 points passed in

Also, clean up some other output functions