### PR TITLE
If base_trajectory gets just one point in a request, add a default starting point

### DIFF
--- a/zebROS_ws/src/base_trajectory/src/base_trajectory.cpp
+++ b/zebROS_ws/src/base_trajectory/src/base_trajectory.cpp
@@ -1327,7 +1327,6 @@ bool callback(base_trajectory::GenerateSpline::Request &msg,
 			msg.points[i].positions.push_back(0);
 		msg.points[0].velocities.clear();
 		msg.points[0].accelerations.clear();
-		return false;
 	}
 
 	// Splines segments are each 1 arbitrary unit long.


### PR DESCRIPTION
Assume the request wanted to start from the current robot position of 0,0,0

Addresses issue https://github.com/FRC900/tasks/issues/892