### PR TITLE
In deploy script, call kill_ros script using sudo

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -129,10 +129,10 @@ do
 done
 echo "Time synchronized."
 
-echo "Killing code on remote "
+echo "Killing code on remotes "
 for i in "${JETSON_ADDR[@]}"
 do
-	ssh ubuntu@$i "/home/ubuntu/2019Offseason/zebROS_ws/kill_ros_.sh"
+	echo ubuntu | ssh -tt ubuntu@$i "sudo /home/ubuntu/2019Offseason/zebROS_ws/kill_ros_.sh"
 done
 echo "ROS Killed on Jetson"
 


### PR DESCRIPTION
This should fix the problem where robot code is run as startup at root but deploy is typically running as user ubuntu. Running kill_ros using sudo should allow the deploy script to stop the robot code when it was run at startup.