### PR TITLE
Reverse child<->parent in realsense to base_link tf

### DIFF
--- a/zebROS_ws/src/controller_node/launch/tape_detection.launch
+++ b/zebROS_ws/src/controller_node/launch/tape_detection.launch
@@ -9,7 +9,7 @@
   -->
   <group ns="robot_state">
 	<param name="robot_description" textfile="$(find controller_node)/urdf/2019_compbot.urdf" />
-	<node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher"/>
+	<node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
   </group>
 
   <arg name="zed_node_name" default="zed_goal" />

--- a/zebROS_ws/src/controller_node/urdf/2019_compbot.urdf
+++ b/zebROS_ws/src/controller_node/urdf/2019_compbot.urdf
@@ -64,19 +64,19 @@
     <link name="zed_imu_link" />
 
 <!-- Realsense2 t265 -->
-	<link name="camera_pose_frame"/>
-    <joint name="camera_joint" type="fixed">
-        <parent link="base_link"/>
-        <child link="camera_pose_frame"/>
+	<link name="rs_t265_pose_frame"/>
+    <joint name="rs_t265_joint" type="fixed">
+        <parent link="rs_t265_pose_frame"/>
+        <child link="base_link"/>
 		<!-- after rotation, this is z, y, -x? 
 			 TODO : verify that the imu and odom frames
                     require this rotation
         <origin xyz="1.04 0 0.216" rpy="0 -1.57 0" />
          -->
-        <origin xyz="-0.216 0.0 1.04" rpy="0 0 0" />
+        <origin xyz="0.216 0.0 -1.04" rpy="0 0 0" />
     </joint>
 	<!--
-		 <link name="camera_link" />
+		 <link name="rs_t265_link" />
 	-->
 
 	<link name="panel_outtake"/>


### PR DESCRIPTION
Change camera-> rs_t265 namespace to match launch file renaming.

Make robot base_link frame a child of rs_t265_pose_frame.  The parent is normally closer to the map frame. Since the realsense generates odom data in the map->odom->base_link frame, this change better fits how the tf tree should work. 

Also, switch to using robot_state_publisher rather than state_publisher to publish urdf transforms.

Needs to be tested on the robot.
Also - bag files from rumble 2019 show another odom->base_link transform, perhaps from the ZED? This will cause problems since tf frames can't have two parents.

Addresses part of https://github.com/FRC900/tasks/issues/912