### PR TITLE
Use std c++ chrono functions in ros_control_boilerplate

### DIFF
--- a/zebROS_ws/src/ros_control_boilerplate/include/ros_control_boilerplate/generic_hw_control_loop.h
+++ b/zebROS_ws/src/ros_control_boilerplate/include/ros_control_boilerplate/generic_hw_control_loop.h
@@ -38,15 +38,12 @@
 */
 
 #pragma once
-#include <time.h>
+#include <chrono>
 #include <ros_control_boilerplate/frc_robot_interface.h>
 #include <ros_control_boilerplate/tracer.h>
 
 namespace ros_control_boilerplate
 {
-// Used to convert seconds elapsed to nanoseconds
-static const double BILLION = 1000000000.0;
-
 /**
  * \brief The control loop - repeatidly calls read() and write() to the hardware interface at a
  * specified frequency
@@ -88,8 +85,7 @@ class GenericHWControlLoop
 		// Timing
 		ros::Duration elapsed_time_;
 		double loop_hz_;
-		struct timespec last_time_;
-		struct timespec current_time_;
+		std::chrono::time_point<std::chrono::steady_clock> last_time_;
 
 		/** \brief Abstract Hardware Interface for your robot */
 		std::shared_ptr<ros_control_boilerplate::FRCRobotInterface> hardware_interface_;

--- a/zebROS_ws/src/ros_control_boilerplate/src/dummy_wpilib_hw.cpp
+++ b/zebROS_ws/src/ros_control_boilerplate/src/dummy_wpilib_hw.cpp
@@ -1,14 +1,10 @@
 #include <ctre/phoenix/platform/Platform.h>
 #include <ros/ros.h>
+#include <chrono>
 extern "C"
 {
 	static uint32_t GetPacketBaseTime() {
-		timespec t;
-		clock_gettime(CLOCK_MONOTONIC, &t);
-
-		// Convert t to milliseconds
-		uint64_t ms = t.tv_sec * 1000ull + t.tv_nsec / 1000000ull;
-		return ms & 0xFFFFFFFF;
+		return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
 	}
 
 	// This is the path for calls going through the new CANAPI.  Accesses
@@ -424,9 +420,7 @@ extern "C" {
 uint64_t HAL_GetFPGATime(int32_t* status)
 {
 	*status = 0;
-	struct timeval tv;
-	gettimeofday(&tv, NULL);
-	return ((uint64_t)tv.tv_sec * 1000000) + tv.tv_usec;
+	return std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
 }
 
 HAL_Bool HAL_Initialize(int32_t, int32_t)

--- a/zebROS_ws/src/ros_control_boilerplate/src/generic_hw_control_loop.cpp
+++ b/zebROS_ws/src/ros_control_boilerplate/src/generic_hw_control_loop.cpp
@@ -62,7 +62,7 @@ GenericHWControlLoop::GenericHWControlLoop(
 	rosparam_shortcuts::shutdownIfError(name_, error);
 
 	// Get current time for use with first update
-	clock_gettime(CLOCK_MONOTONIC, &last_time_);
+	last_time_ = std::chrono::steady_clock::now();
 
 	desired_update_period_ = ros::Duration(1.0 / loop_hz_);
 }
@@ -79,12 +79,11 @@ void GenericHWControlLoop::run(void)
 
 void GenericHWControlLoop::update(void)
 {
-	// Get change in time
-	clock_gettime(CLOCK_MONOTONIC, &current_time_);
-	elapsed_time_ =
-		ros::Duration((double)current_time_.tv_sec - (double)last_time_.tv_sec +
-				      ((double)current_time_.tv_nsec - (double)last_time_.tv_nsec) / BILLION);
-	last_time_ = current_time_;
+	// Get change in time in seconds
+	const auto current_time = std::chrono::steady_clock::now();
+	std::chrono::duration<double> elapsed_seconds = current_time - last_time_;
+	elapsed_time_ = ros::Duration(elapsed_seconds.count());
+	last_time_ = current_time;
 
 	// ROS_DEBUG_STREAM_THROTTLE_NAMED(1, "generic_hw_main","Sampled update loop with elapsed
 	// time " << elapsed_time_.toSec());


### PR DESCRIPTION
Should make the code portable to windows - or at least the time code.