### PR TITLE
Add virtual destructor to TalonControllerInterface to make derived class

### DIFF
--- a/zebROS_ws/src/talon_controllers/include/talon_controllers/talon_controller_interface.h
+++ b/zebROS_ws/src/talon_controllers/include/talon_controllers/talon_controller_interface.h
@@ -1003,6 +1003,8 @@ class TalonControllerInterface
 		{
 		}
 
+		virtual ~TalonControllerInterface() {}
+
 		// Standardize format for reading params for
 		// motor controller
 		virtual bool readParams(ros::NodeHandle &n, TalonCIParams &params)


### PR DESCRIPTION
destructors work correctly in all cases

See explanation here https://stackoverflow.com/questions/10024796/c-virtual-functions-but-no-virtual-destructors