### PR TITLE
Set main hwi loop to FIFO priority

### DIFF
--- a/jetson_setup/master.sh
+++ b/jetson_setup/master.sh
@@ -6,6 +6,10 @@ sudo sysctl -p
 sudo rfkill block wifi  
 sudo rfkill block bluetooth
 
+# Allow scheduling of RT threads without cgroups
+sysctl -w kernel.sched_rt_runtime_us=-1
+ulimit -r unlimited
+
 /home/ubuntu/2019Offseason/jetson_setup/can_up.sh
 
 . /home/ubuntu/2019Offseason/zebROS_ws/ROSJetsonMaster.sh

--- a/zebROS_ws/ROSJetsonMaster.sh
+++ b/zebROS_ws/ROSJetsonMaster.sh
@@ -26,6 +26,7 @@ elif [ -f /home/admin/rio_bashrc.sh ] ; then
     export ROS_IP=10.9.0.2
     export LD_LIBRARY_PATH=/home/admin/wpilib:$LD_LIBRARY_PATH
     swapon /dev/sda5
+	ulimit -r unlimited
 else
     echo "Unknown environment! Trying to proceed anyway using local environment."
     source /opt/ros/melodic/setup.bash

--- a/zebROS_ws/src/ros_control_boilerplate/src/frcrobot_hw_interface.cpp
+++ b/zebROS_ws/src/ros_control_boilerplate/src/frcrobot_hw_interface.cpp
@@ -610,15 +610,15 @@ void FRCRobotHWInterface::init(void)
 	}
 
 #ifdef __linux__
-	struct sched_param schedParam;
+	struct sched_param schedParam{};
 
 	schedParam.sched_priority = sched_get_priority_min(SCHED_RR);
-	auto rc = sched_setscheduler(gettid(), SCHED_RR, &schedParam);
-	ROS_INFO_STREAM("sched_setscheduler() returned " << rc
+	auto rc = pthread_setschedparam(pthread_self(), SCHED_RR, &schedParam);
+	ROS_INFO_STREAM("pthread_setschedparam() returned " << rc
 			<< " priority = " << schedParam.sched_priority
 			<< " errno = " << errno << " (" << strerror(errno) << ")");
+	pthread_setname_np(pthread_self(), "hwi_main_loop");
 #endif
-
 
 	ROS_INFO_NAMED("frcrobot_hw_interface", "FRCRobotHWInterface Ready.");
 }
@@ -633,7 +633,9 @@ void FRCRobotHWInterface::ctre_mc_read_thread(std::shared_ptr<ctre::phoenix::mot
 											std::shared_ptr<std::mutex> mutex,
 											std::unique_ptr<Tracer> tracer)
 {
+#ifdef __linux__
 	pthread_setname_np(pthread_self(), "ctre_mc_read");
+#endif
 	ros::Duration(2).sleep(); // Sleep for a few seconds to let CAN start up
 	ros::Rate rate(100); // TODO : configure me from a file or
 						 // be smart enough to run at the rate of the fastest status update?
@@ -904,7 +906,9 @@ void FRCRobotHWInterface::pdp_read_thread(int32_t pdp,
 		std::shared_ptr<std::mutex> mutex,
 		std::unique_ptr<Tracer> tracer)
 {
+#ifdef __linux__
 	pthread_setname_np(pthread_self(), "pdp_read");
+#endif
 	ros::Duration(2).sleep(); // Sleep for a few seconds to let CAN start up
 	ros::Rate r(20); // TODO : Tune me?
 	int32_t status = 0;
@@ -955,7 +959,9 @@ void FRCRobotHWInterface::pcm_read_thread(HAL_CompressorHandle compressor_handle
 										  std::shared_ptr<std::mutex> mutex,
 										  std::unique_ptr<Tracer> tracer)
 {
+#ifdef __linux__
 	pthread_setname_np(pthread_self(), "pcm_read");
+#endif
 	ros::Duration(2).sleep(); // Sleep for a few seconds to let CAN start up
 	ros::Rate r(20); // TODO : Tune me?
 	int32_t status = 0;


### PR DESCRIPTION
This sets it to higher priority than most everything else on the robot. This means that no matter what else is running it should still get an appropriate amount of CPU time.

Definitely needs to be tested on the robot.

See https://github.com/FRC900/prog_gen_tasks/issues/48